### PR TITLE
Feature/UI

### DIFF
--- a/Content/Levels/MainMenuLevel.umap
+++ b/Content/Levels/MainMenuLevel.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f89a20a41d03f5a25a86df7e7ed4e2a9b25dda5b9689b222240df88a57aa473
+size 54833

--- a/Content/MainMenuLevel.umap
+++ b/Content/MainMenuLevel.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4018319f2003c23030e5634d777363aff52e31417e9f16fa9a0cb9d86d2d133e
+size 2229

--- a/Content/MainMenuMap.umap
+++ b/Content/MainMenuMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9624e4c211c9cf292f55ac306292db950a186e9587491d0468d5919c64789a21
-size 74736
+oid sha256:f57ff56b9fcce1b0860d1f7acb1654cd5dec956680ffc85b08f95f3fa7f971f6
+size 2251

--- a/Content/Map/GameMap.umap
+++ b/Content/Map/GameMap.umap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58b0d7ca69f6b5ef767457a5484dde4546c2b1f1826e539b7d641fe030c68f2d
-size 128621

--- a/Content/UITexture/4QuickSlot.uasset
+++ b/Content/UITexture/4QuickSlot.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:681338da3aaf037287b35fcbbef9f51259bbf01f8d953e26a547965c2de0a86e
+size 505528

--- a/Content/UITexture/QuickSlot.uasset
+++ b/Content/UITexture/QuickSlot.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efa1040725b951c0fd9675efb6e67974ab8fbd725e81d198cde510f1eac4d1b1
-size 751357

--- a/Content/Widget/WBP_HUDWidget.uasset
+++ b/Content/Widget/WBP_HUDWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3961869d2b44cd84fdab587a5bb760dfd01dee94625d14708fa8b76ead3ca052
-size 78777
+oid sha256:ffa9ca3169a589ca2dd4b6ce11b08e65e641ef420317edd2c85a281709d886ec
+size 78749

--- a/Source/CH03Project/Private/HUDWidget.cpp
+++ b/Source/CH03Project/Private/HUDWidget.cpp
@@ -1,23 +1,12 @@
 #include "HUDWidget.h"
 #include "Components/ProgressBar.h"
 #include "Components/TextBlock.h"
+#include "Components/Image.h"
 
 void UHUDWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
-	//UMyGameInstance* GameInstance = Cast<UMyGameInstance>(UGameplayStatics::GetGameInstance(GetWorld()));
-	//if (GameInstance)
-	//{
-	//	// GameInstance의 OnHealthChanged 델리게이트에 HUDWidget의 UpdateHealth 함수 바인딩
-	//	GameInstance->OnHealthChanged.AddDynamic(this, &UHUDWidget::UpdateHealth);
-	//	// GameInstance의 OnBulletChanged 델리게이트에 HUDWidget의 UpdateBullet 함수 바인딩
-	//	GameInstance->OnBulletChanged.AddDynamic(this, &UHUDWidget::UpdateBullet);
-
-	//	// HUD가 생성될 때 초기 체력과 총알 값을 업데이트 (선택 사항)
-	//	UpdateHealth(GameInstance->CurrentPlayerHealth, GameInstance->MaxPlayerHealth);
-	//	UpdateBullet(GameInstance->CurrentPlayerBullet);
-	//}
 }
 
 void UHUDWidget::UpdateHealth(float CurrentHealth, float MaxHealth)
@@ -54,5 +43,33 @@ void UHUDWidget::UpdateScore(int32 CurrentScore)
 	if (HUDScoreNum)
 	{
 		HUDScoreNum->SetText(FText::AsNumber(CurrentScore));
+	}
+}
+
+void UHUDWidget::UpdateSubQuest(int32 QuestIndex, const TArray<FString>& MissionTexts)
+{
+	if (SubQuestText && MissionTexts.IsValidIndex(QuestIndex))
+	{
+		FString QuestText = MissionTexts[QuestIndex];
+		SubQuestText->SetText(FText::FromString(QuestText));
+	}
+}
+
+void UHUDWidget::UpdateHiddenQuest(bool bIsGetStatue, int32 StatueCount)
+{
+	if (HiddenQuestText)
+	{
+		HiddenQuestText->SetVisibility(ESlateVisibility::Visible);
+	}
+
+	if (StatueNum)
+	{
+		StatueNum->SetVisibility(ESlateVisibility::Visible);
+		StatueNum->SetText(FText::AsNumber(StatueCount));
+	}
+
+	if (HiddenQuestOutline)
+	{
+		HiddenQuestOutline->SetVisibility(ESlateVisibility::Visible);
 	}
 }

--- a/Source/CH03Project/Public/HUDWidget.h
+++ b/Source/CH03Project/Public/HUDWidget.h
@@ -6,6 +6,7 @@
 
 class UProgressBar;
 class UTextBlock;
+class UImage;
 
 UCLASS()
 class CH03PROJECT_API UHUDWidget : public UUserWidget
@@ -21,6 +22,11 @@ public:
 	void UpdateBossHP(float CurrentBossHealth, float MaxBossHealth);
 	UFUNCTION(BlueprintCallable, Category = "UI|HUD")
 	void UpdateScore(int32 CurrentScore);
+	UFUNCTION(BlueprintCallable, Category = "UI|HUD")
+	void UpdateSubQuest(int32 QuestIndex, const TArray<FString>& MissionTexts);
+	UFUNCTION(BlueprintCallable, Category = "UI|HUD")
+	void UpdateHiddenQuest(bool bIsGetStatue, int32 StatueCount);
+
 
 
 protected:
@@ -36,4 +42,14 @@ protected:
 	UProgressBar* BossHealthBar;
 	UPROPERTY(meta = (BindWidget))
 	UTextBlock* HUDScoreNum;
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* SubQuestText;
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* QuestNumText;
+	UPROPERTY(meta = (BindWidget))
+	UImage* HiddenQuestOutline;
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* StatueNum;
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* HiddenQuestText;
 };

--- a/Source/CH03Project/Public/MenuWidget.h
+++ b/Source/CH03Project/Public/MenuWidget.h
@@ -7,6 +7,7 @@
 class UButton;
 class UTextBlock;
 
+
 UCLASS()
 class CH03PROJECT_API UMenuWidget : public UUserWidget
 {


### PR DESCRIPTION
히든퀘스트 띄우는 함수, 서브퀘스트 띄우는 함수 추가.
퀵슬롯 5칸에서 4칸짜리로 변경
기존에 쓰던 메인메뉴 띄우는 레벨과 HUD를 임시로 띄우던 레벨 삭제