### PR TITLE
[리펙토링] BaseActor 컴포넌트 분리 및 적 처치 시 점수 획득 추가

### DIFF
--- a/Content/AI/Characters/BP_AI_Boss.uasset
+++ b/Content/AI/Characters/BP_AI_Boss.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93a96b9acab44dbce4361f835c7f69d497aa8217028abfcaa2b0a23d4df1e444
+size 26885

--- a/Content/AI/Characters/BP_AI_Melee.uasset
+++ b/Content/AI/Characters/BP_AI_Melee.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a5a7660b2e26a2b3148038313164c1de0a0465b8c093e0d6fd5ab850fbd8bd4
-size 120194
+oid sha256:ea04568187eacd2d31fea9339667e05d8927ad7e82670f05887055cbeb7ec485
+size 120782

--- a/Content/AI/Characters/BP_AI_Ranged.uasset
+++ b/Content/AI/Characters/BP_AI_Ranged.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3603a999ac1fd6d7e0f4fcaf7ae719c047ab754565fdd25e1ef442d4521d8a9d
-size 131618
+oid sha256:7594f1df9ed7578170191a46cb6429efcc683f8e035e7a2372c41fffcc371ac4
+size 132630

--- a/Content/Character/BP_MyCharacter.uasset
+++ b/Content/Character/BP_MyCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f2224bfd4b4ed0f9fef7c25a5ce127821d2d13f6c96d0acde0e749bd3230588
-size 37606
+oid sha256:a099374b15ad747d1bcc06dd52c29405b6431b935a505fc3d93f77de84acc3d9
+size 39072

--- a/Content/Levels/TestLevel.umap
+++ b/Content/Levels/TestLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b66755185fe352f3228f42eaf4f896d132ecf1f6cfa5ff57ca06379d71fe0cf7
-size 107418
+oid sha256:a8f76a4b41f2783acf53183517e1adf0ea414abf3f9f033a85223e77477089db
+size 87187

--- a/Content/Levels/TestLevel1.umap
+++ b/Content/Levels/TestLevel1.umap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b266e5bf8acd19c641624401df65282968abb76711cd20be94708f665ab665
-size 93890

--- a/Source/CH03Project/Private/BaseActor.cpp
+++ b/Source/CH03Project/Private/BaseActor.cpp
@@ -6,9 +6,9 @@ ABaseActor::ABaseActor()
 {	
 	PrimaryActorTick.bCanEverTick = true;
 
-	BaseStatComponent = CreateDefaultSubobject<UBaseStatComponent>(TEXT("StatComponent"));
+	/*BaseStatComponent = CreateDefaultSubobject<UBaseStatComponent>(TEXT("StatComponent"));
 	DamageComponent = CreateDefaultSubobject<UDamageComponent>(TEXT("DamageComponent"));
-	DamageComponent->AttackTokenCount = 1;
+	DamageComponent->AttackTokenCount = 1;*/
 }
 
 void ABaseActor::BeginPlay()

--- a/Source/CH03Project/Private/BaseStatComponent.cpp
+++ b/Source/CH03Project/Private/BaseStatComponent.cpp
@@ -9,8 +9,8 @@
 #include "BrainComponent.h"
 #include "BaseEnemy.h"
 #include "EnemyAIController.h"
-
 #include "Engine/Engine.h"
+#include "GameStatePlay.h"
 
 
 UBaseStatComponent::UBaseStatComponent()
@@ -116,6 +116,12 @@ void UBaseStatComponent::OnDeath()
 			}
 			EnemyAICon->SetStateAsDead();
 		}
+	}
+
+	AGameStatePlay* GameStatePlay = Cast<AGameStatePlay>(UGameplayStatics::GetGameState(GetWorld()));
+	if (GameStatePlay)
+	{
+		GameStatePlay->AddScore(KillScore);
 	}
 
 	AMyPlayerController* PC = Cast<AMyPlayerController>(OwnerCharacter->GetController());

--- a/Source/CH03Project/Private/MyCharacter.cpp
+++ b/Source/CH03Project/Private/MyCharacter.cpp
@@ -1,4 +1,4 @@
-#include "MyCharacter.h"
+﻿#include "MyCharacter.h"
 #include "EnhancedInputComponent.h"
 #include "MyPlayerController.h"
 #include "DamageComponent.h"
@@ -65,6 +65,8 @@ void AMyCharacter::BeginPlay()
 	{
 		GetCharacterMovement()->MaxWalkSpeed = NormalSpeed;
 	}
+
+	DamageComponent = FindComponentByClass<UDamageComponent>();
 }
 
 void AMyCharacter::PossessedBy(AController* NewController)

--- a/Source/CH03Project/Public/BaseActor.h
+++ b/Source/CH03Project/Public/BaseActor.h
@@ -22,8 +22,8 @@ protected:
 public:
 	virtual void Tick(float DeltaTime) override;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+	/*UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
 	UBaseStatComponent* BaseStatComponent;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
-	UDamageComponent* DamageComponent;
+	UDamageComponent* DamageComponent;*/
 };

--- a/Source/CH03Project/Public/BaseStatComponent.h
+++ b/Source/CH03Project/Public/BaseStatComponent.h
@@ -35,6 +35,9 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "BaseStat")
 	float ImmuneToDamageTime;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "BaseStat")
+	int32 KillScore;
+
 public:
 	//virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 

--- a/Source/CH03Project/Public/MyCharacter.h
+++ b/Source/CH03Project/Public/MyCharacter.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "CoreMinimal.h"
 #include "BaseActor.h"
@@ -74,7 +74,7 @@ protected:
 	// Timer
 	FTimerHandle ShootTimerHandle;
 
-
+	UDamageComponent* DamageComponent;
 
 public:
 	AMyCharacter();
@@ -126,4 +126,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Token")
 	void ReturnAttackToken(int32 Amount);
+
+
+
 };


### PR DESCRIPTION
BaseActor에서 Damage, BaseStat 컴포넌트를 분리하였습니다.

Enemy 처치시 점수를 획득할 수 있습니다.

점수는 BaseStat에서 설정할 수 있습니다.