### PR TITLE
[리펙토링] 원거리 공격 수정

### DIFF
--- a/Source/CH03Project/Private/HitRangedComponent.cpp
+++ b/Source/CH03Project/Private/HitRangedComponent.cpp
@@ -6,7 +6,8 @@
 #include "DrawDebugHelpers.h"
 #include "Engine/World.h"
 #include "Engine/EngineTypes.h"
-
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/Character.h"
 
 UHitRangedComponent::UHitRangedComponent()
 {
@@ -29,42 +30,73 @@ void UHitRangedComponent::BeginPlay()
 
 void UHitRangedComponent::FireTrace()
 {
-	if (!SkeletalMeshComp)
+	if (!GetWorld())
 	{
 		return;
 	}
-	FVector SocketLocation = SkeletalMeshComp->GetSocketLocation(SocketName);
-	FRotator SocketRotation = SkeletalMeshComp->GetSocketRotation(SocketName);
-	FVector SocketForward = SocketRotation.Vector();
 
-	FVector StartLocation = SocketLocation + (SocketForward * StartOffset.X);
-	FVector EndLocation = StartLocation + (SocketForward * TraceDistance);
-
-	FCollisionQueryParams TraceParams;
-	TraceParams.AddIgnoredActor(GetOwner());
-	TraceParams.bTraceComplex = false;
-
-
-	FHitResult HitResult;
-	bool bHit = GetWorld()->LineTraceSingleByChannel(HitResult, StartLocation, EndLocation, ECollisionChannel::ECC_GameTraceChannel1, TraceParams);
-
-	DrawDebugLine(GetWorld(), StartLocation, EndLocation, bHit ? FColor::Red : FColor::Green, false, 2.0f);
-
-	if (bHit)
+	ACharacter* PlayerChar = UGameplayStatics::GetPlayerCharacter(GetWorld(), 0);
+	if (PlayerChar)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("Hit Actor: %s"), *HitResult.GetActor()->GetName());
-		if (HitResult.GetActor() && HitResult.GetActor()->ActorHasTag("Player"))
-		{
-			UE_LOG(LogTemp, Warning, TEXT("Hit Player"));
-
-			//나 자신의 대미지 컴포넌트
-			UDamageComponent* DamageComp = GetOwner()->FindComponentByClass<UDamageComponent>();
-			if (DamageComp)
-			{
-				DamageComp->TransDamage(HitResult.GetActor());
-			}
-		}
+		CachedPlayerLocation = PlayerChar->GetActorLocation();
+		UE_LOG(LogTemp, Warning, TEXT("Player Location: %s"), *CachedPlayerLocation.ToString());
+	}
+	else
+	{
+		return;
 	}
 
+	GetWorld()->GetTimerManager().SetTimer(
+		TimerHandle_FireTrace,
+		this,
+		&UHitRangedComponent::StartAttack,
+		AttackDelayTime,
+		false
+	);
 }
 
+void UHitRangedComponent::StartAttack()
+{
+	if (!SkeletalMeshComp || !GetWorld())
+	{
+		return;
+	}
+
+	const FVector StartLocation = SkeletalMeshComp->GetSocketLocation(SocketName);
+	const FVector EndLocation = CachedPlayerLocation;
+
+	FCollisionQueryParams TraceParams(SCENE_QUERY_STAT(FireTrace), false, GetOwner());
+	TraceParams.bTraceComplex = false;
+
+	FHitResult HitResult(ForceInit);
+	const bool bHit = GetWorld()->LineTraceSingleByChannel(
+		HitResult,
+		StartLocation,
+		EndLocation,
+		ECollisionChannel::ECC_GameTraceChannel1,
+		TraceParams
+	);
+
+#if WITH_EDITOR
+
+	DrawDebugLine(
+		GetWorld(),
+		StartLocation,
+		EndLocation,
+		bHit ? FColor::Red : FColor::Green,
+		false,
+		2.0f
+	);
+#endif
+
+	
+	if (bHit && HitResult.GetActor() && HitResult.GetActor()->ActorHasTag("Player"))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Hit Player"));
+
+		if (UDamageComponent* DamageComp = GetOwner()->FindComponentByClass<UDamageComponent>())
+		{
+			DamageComp->TransDamage(HitResult.GetActor());
+		}
+	}
+}

--- a/Source/CH03Project/Public/HitRangedComponent.h
+++ b/Source/CH03Project/Public/HitRangedComponent.h
@@ -19,9 +19,14 @@ protected:
 	UPROPERTY()
 	USkeletalMeshComponent* SkeletalMeshComp;
 
+	FTimerHandle TimerHandle_FireTrace;
+	FVector CachedPlayerLocation;
+
 public:
 	UFUNCTION(BlueprintCallable)
 	void FireTrace();
+	UFUNCTION(BlueprintCallable)
+	void StartAttack();
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "HitRanged")
 	float TraceDistance;
@@ -29,6 +34,7 @@ public:
 	FVector StartOffset;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "HitRanged")
 	FName SocketName;
-
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "HitRanged")
+	float AttackDelayTime;
 		
 };


### PR DESCRIPTION
원거리 공격 방식을 수정했습니다.

1.플레이어 위치를 목표로 합니다.
2.AttackDelayTime 만큼 지연되어 공격합니다.

시작 위치는 SocketName의 스켈레탈의 소켓 위치 입니다.