### PR TITLE
[리펙토링] 퀘스트 아이템 생성, 특정구간 외 Enemy 삭제

### DIFF
--- a/Content/AI/Characters/BP_AI_Melee.uasset
+++ b/Content/AI/Characters/BP_AI_Melee.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8279f79d416673d626499ed9ae70e64609b28dfb557f3069eb3fd074ada628ee
-size 137701
+oid sha256:edcefc2f422271e3a695d6c6c4aa21e43b901fd4f431ae7df20f413eeadbe1a3
+size 142021

--- a/Content/AI/Characters/BP_AI_Ranged.uasset
+++ b/Content/AI/Characters/BP_AI_Ranged.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:565244c4a5cdc61b06b71c9dadcd4f4cdca426b02fc4c981809bb3840a4d8017
-size 143729
+oid sha256:868de0e855ee41eb8f83a47b97d879eaf73d12db028c8427346eca1c9f5966b1
+size 148028

--- a/Content/DataTables/SubTextTable.uasset
+++ b/Content/DataTables/SubTextTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:927e7df756febce344f52af091a75dd53f93940e151c7129f4dee5dce8b28f0c
-size 2298
+oid sha256:540f54e1f9d501f6c660311e1d799bcc88bbf40d651f0e0463d0e99ac6894c31
+size 2369

--- a/Content/Items/BP_Pickup_CardKey.uasset
+++ b/Content/Items/BP_Pickup_CardKey.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1419ebbe2268a947e0a576ebed77126b3aa32678010ed7313561d9fc2f89577d
-size 35106
+oid sha256:97a68a746503bc5ae42c35b93d11d9e3aa139a4e96ab10ffbdfc56d74b5eb03e
+size 36203

--- a/Content/Levels/MainLevel.umap
+++ b/Content/Levels/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec917b49d96b967b23207ef61e3884dd7fec59d6afd53c61c19edae611679dbe
-size 2299383
+oid sha256:738ef931947e4f63a97af1f9cec0a1bfb04057bd8a7a6f30e39b9c98dbb77dcb
+size 2314757

--- a/Source/CH03Project/Private/BaseStatComponent.cpp
+++ b/Source/CH03Project/Private/BaseStatComponent.cpp
@@ -168,9 +168,8 @@ void UBaseStatComponent::OnDeath()
 	if (GameModePlay)
 	{
 		GameModePlay->AddScore(KillScore);
-		GameModePlay->AddKillCount(1);
-		//킬로그 전송필요
-		//처치UI필요
+		GameModePlay->SetLastLocation(OwnerCharacter->GetActorLocation());
+		GameModePlay->AddKillCount(1);		
 	}
 
 

--- a/Source/CH03Project/Private/QuestObjectComponent.cpp
+++ b/Source/CH03Project/Private/QuestObjectComponent.cpp
@@ -1,10 +1,10 @@
 ﻿#include "QuestObjectComponent.h"
-
+#include "QuestTypeA.h"
+#include "Kismet/GameplayStatics.h"
 
 UQuestObjectComponent::UQuestObjectComponent()
 {
 	PrimaryComponentTick.bCanEverTick = false;
-
 }
 
 
@@ -19,7 +19,17 @@ void UQuestObjectComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	Super::EndPlay(EndPlayReason);
 	if (EndPlayReason == EEndPlayReason::Destroyed)
 	{
-		
+		UE_LOG(LogTemp, Warning, TEXT("퀘스트 오브젝트 컴포넌트가 파괴되었습니다."));
+		AQuestTypeA* QuestActor = Cast<AQuestTypeA>(UGameplayStatics::GetActorOfClass(GetWorld(), AQuestTypeA::StaticClass()));
+		if (QuestActor)
+		{
+			QuestActor->UpdateKeyItemCount();
+			UE_LOG(LogTemp, Warning, TEXT("퀘스트 오브젝트가 파괴되었습니다: %s"), *QuestActor->GetName());
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("퀘스트 오브젝트 컴포넌트가 소속된 액터를 찾을 수 없습니다."));
+		}
 	}
 }
 

--- a/Source/CH03Project/Public/QuestTypeA.h
+++ b/Source/CH03Project/Public/QuestTypeA.h
@@ -5,7 +5,10 @@
 #include "EnemySpawnRow.h"
 #include "GameModePlay.h"
 #include "Components/BoxComponent.h"
+#include "GameFramework/Volume.h"
+#include "Kismet/GameplayStatics.h"
 #include "QuestTypeA.generated.h"
+
 
 class ASpawnAreaActor;
 class APickupItem;
@@ -44,7 +47,7 @@ public:
 	UFUNCTION()
 	void UpdateKillCount(int32 Points);
 	UFUNCTION()
-	void UpdateKeyItemCount(int32 Points);
+	void UpdateKeyItemCount();
 
 	//스폰데이터어레이
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "QuestTypeA")
@@ -83,7 +86,10 @@ public:
 
 	void SpawnEnemy();
 
-	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "QuestTypeA")
+	AVolume* EnemyAliveVolume;
+
+	void DestroyAllEnemies();
 
 	
 


### PR DESCRIPTION
특정 횟수 Enemy를 처치하면 해당 위치에 KeyItem이 드랍됩니다.

설정된 구간 외 Enemy를 삭제하는 기능을 추가했습니다.

AI Enemy가 죽을 때 매쉬가 No collision으로 변경됩니다.

